### PR TITLE
adding support for changing attribute Scope

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Dec 26 13:17:50 MST 2014
+#Tue Aug 16 10:05:01 PDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2-all.zip

--- a/src/main/java/com/segment/analytics/android/integrations/localytics/LocalyticsIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/localytics/LocalyticsIntegration.java
@@ -17,7 +17,6 @@ import com.segment.analytics.integrations.TrackPayload;
 import java.util.Collections;
 import java.util.Map;
 
-import static com.localytics.android.Localytics.ProfileScope.APPLICATION;
 import static com.segment.analytics.Analytics.LogLevel;
 import static com.segment.analytics.internal.Utils.isNullOrEmpty;
 import static com.segment.analytics.internal.Utils.isOnClassPath;

--- a/src/main/java/com/segment/analytics/android/integrations/localytics/LocalyticsIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/localytics/LocalyticsIntegration.java
@@ -44,6 +44,8 @@ public class LocalyticsIntegration extends Integration<Void> {
 
   final Logger logger;
   final boolean hasSupportLibOnClassPath;
+  final boolean organizationScope;
+  final Localytics.ProfileScope attributeScope;
   ValueMap customDimensions;
 
   LocalyticsIntegration(Analytics analytics, ValueMap settings) {
@@ -63,6 +65,13 @@ public class LocalyticsIntegration extends Integration<Void> {
     customDimensions = settings.getValueMap("dimensions");
     if (customDimensions == null) {
       customDimensions = new ValueMap(Collections.<String, Object>emptyMap());
+    }
+
+    organizationScope = settings.getBoolean("setOrganizationScope", false);
+    if (organizationScope) {
+      attributeScope = Localytics.ProfileScope.ORGANIZATION;
+    } else {
+      attributeScope = Localytics.ProfileScope.APPLICATION;
     }
   }
 
@@ -141,8 +150,8 @@ public class LocalyticsIntegration extends Integration<Void> {
     for (Map.Entry<String, Object> entry : traits.entrySet()) {
       String key = entry.getKey();
       String value = String.valueOf(entry.getValue());
-      Localytics.setProfileAttribute(key, value, APPLICATION);
-      logger.verbose("Localytics.setProfileAttribute(%s, %s, %s);", key, value, APPLICATION);
+      Localytics.setProfileAttribute(key, value, attributeScope);
+      logger.verbose("Localytics.setProfileAttribute(%s, %s, %s);", key, value, attributeScope);
     }
   }
 

--- a/src/test/java/com/segment/analytics/android/integrations/localytics/LocalyticsTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/localytics/LocalyticsTest.java
@@ -59,7 +59,7 @@ public class LocalyticsTest {
 
   @Test public void initialize() {
     LocalyticsIntegration integration = new LocalyticsIntegration(analytics,
-        new ValueMap().putValue("appKey", "foo")
+        new ValueMap().putValue("appKey", "foo").putValue("setOrganizationScope", true)
             .putValue("dimensions", new ValueMap().putValue("foo", "bar")));
 
     verifyStatic();
@@ -67,6 +67,8 @@ public class LocalyticsTest {
     verifyStatic();
     Localytics.setLoggingEnabled(true);
     assertThat(integration.customDimensions).isEqualTo(Collections.singletonMap("foo", "bar"));
+    verifyStatic();
+    assertThat(integration.attributeScope).isEqualTo(Localytics.ProfileScope.ORGANIZATION);
   }
 
   @Test public void activityResume() {


### PR DESCRIPTION
@f2prateek This adds the ability to set the value of Localytics `ProfileScope` to Organization or Application to offer a better experience in Localytics for publisher's with more than one app.
