### PR TITLE
Bump Localytics version to 5.1.0.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,13 +36,13 @@ android {
 dependencies {
   repositories {
     mavenCentral()
-    maven { url 'http://maven.localytics.com/public' }
+    maven { url 'https://maven.localytics.com/public' }
   }
 
   provided 'com.segment.analytics.android:analytics:4.0.0'
 
-  compile 'com.localytics.android:library:4.5.1'
   compile 'com.android.support:support-v4:25.2.0'
+  compile 'com.localytics.android:library:5.1.0'
 
   testCompile 'junit:junit:4.12'
   testCompile('org.robolectric:robolectric:3.3.2') {

--- a/src/main/java/com/segment/analytics/android/integrations/localytics/LocalyticsIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/localytics/LocalyticsIntegration.java
@@ -60,8 +60,10 @@ public class LocalyticsIntegration extends Integration<Void> {
     logger.verbose("Localytics.setLoggingEnabled(%s);", loggingEnabled);
 
     String appKey = settings.getString("appKey");
-    Localytics.integrate(analytics.getApplication(), appKey);
-    logger.verbose("Localytics.integrate(context, %s);", appKey);
+    Localytics.integrate(analytics.getApplication());
+    logger.verbose("Localytics.integrate(context);");
+    Localytics.setOption("ll_app_key", appKey);
+    logger.verbose("Localytics.setOption(%s);", appKey);
 
     hasSupportLibOnClassPath = isOnClassPath("android.support.v4.app.FragmentActivity");
     customDimensions = settings.getValueMap("dimensions");

--- a/src/test/java/com/segment/analytics/android/integrations/localytics/LocalyticsTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/localytics/LocalyticsTest.java
@@ -63,7 +63,9 @@ public class LocalyticsTest {
             .putValue("dimensions", new ValueMap().putValue("foo", "bar")));
 
     verifyStatic();
-    Localytics.integrate(RuntimeEnvironment.application, "foo");
+    Localytics.integrate(RuntimeEnvironment.application);
+    verifyStatic();
+    Localytics.setOption("ll_app_key", "foo");
     verifyStatic();
     Localytics.setLoggingEnabled(true);
     assertThat(integration.customDimensions).isEqualTo(Collections.singletonMap("foo", "bar"));


### PR DESCRIPTION
This PR bumps the Segment-Localytics SDK dependency to version 5.1.0.

Note 5.1.0 has changed the definition of the `integrate` method, like so:
* Previous: Localytics.integrate(context, appKey);
* Now we must implement the above method as two separate methods:
** Localytics.integrate(context);
** Localytics.setOptions("ll_app_key", appKey);

E2E testing confirms that data sent from our test app populates to the Localytics dashboard as expected.